### PR TITLE
fix a typo in readme file. 31 byte -> 32 byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Provides these functions:
 
   Produces the public key from a private key
 
-  * `privateKey` must be a 31-bytes hex-encoded string, i.e. 64 characters.
+  * `privateKey` must be a 32-bytes hex-encoded string, i.e. 64 characters.
   * Returns a public key as also 32-bytes hex-encoded.
 
 Made for integration with [Nostr](https://github.com/fiatjaf/nostr).


### PR DESCRIPTION
Fixes https://github.com/nbd-wtf/dart-bip340/issues/2