### PR TITLE
fix: pad left bytes

### DIFF
--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -10,7 +10,7 @@ List<int> taggedHash(String tag, List<int> msg) {
 }
 
 List<int> bigToBytes(BigInt integer) {
-  var hexNum = integer.toRadixString(16);
+  var hexNum = integer.toRadixString(16).padLeft(64, "0");
   if (hexNum.length % 2 == 1) {
     hexNum = '0' + hexNum;
   }


### PR DESCRIPTION
@fiatjaf the byte array should be padded with 0 zeros at beginning. This was a reason why this library was failing on signatures where private key have public key with 0's at beginning 

Fixes #5