### PR TITLE
feat: variable length of message

### DIFF
--- a/lib/src/bip340.dart
+++ b/lib/src/bip340.dart
@@ -11,7 +11,7 @@ import './helpers.dart';
 /// It returns the signature as a string of 64 bytes hex-encoded, i.e., 128 characters.
 /// For more information on BIP-340 see bips.xyz/340.
 String sign(String privateKey, String message, String aux) {
-  List<int> bmessage = hex.decode(message.padLeft(64, '0'));
+  List<int> bmessage = hex.decode(message);
   List<int> baux = hex.decode(aux.padLeft(64, '0'));
   BigInt d0 = BigInt.parse(privateKey, radix: 16);
 
@@ -74,7 +74,7 @@ String sign(String privateKey, String message, String aux) {
 /// It returns true if the signature is valid, false otherwise.
 /// For more information on BIP-340 see bips.xyz/340.
 bool verify(String? publicKey, String message, String signature) {
-  List<int> bmessage = hex.decode(message.padLeft(64, '0'));
+  List<int> bmessage = hex.decode(message);
 
   List<int> bsig = hex.decode(signature.padLeft(128, '0'));
   var r = bsig.sublist(0, 32);


### PR DESCRIPTION
In April 20 last year the limit of message was lifted and the message can now have variable length

https://github.com/bitcoin/bips/commit/200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb