### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Provides these functions:
   Generates a schnorr signature using the BIP-340 scheme.
 
   * `privateKey` must be 32-bytes hex-encoded, i.e., 64 characters.
-  * `message` must also be 32-bytes hex-encoded (a hash of the _actual_ message).
+  * `message` must also be hex-encoded (a hash of the _actual_ message).
   * `aux ` must be 32-bytes random bytes, generated at signature time.
   * Returns the signature as a string of 64 bytes hex-encoded, i.e., 128 characters.
 
@@ -23,7 +23,7 @@ Provides these functions:
   Verifies a schnorr signature using the BIP-340 scheme.
 
   * `publicKey` must be 32-bytes hex-encoded, i.e., 64 characters (if you have a pubkey with 33 bytes just remove the first one).
-  * `message` must also be 32-bytes hex-encoded (a hash of the _actual_ message).
+  * `message` must also be hex-encoded (a hash of the _actual_ message).
   * `signature` must be 64-bytes hex-encoded, i.e., 128 characters.
   * Returns true if the signature is valid, false otherwise.
 


### PR DESCRIPTION
There is an old comment in readme, the message does not have to be exactly 32-bytes anymore. 